### PR TITLE
[Feat] Post Repository, DTO 및 Service 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-h2console'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-h2console'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/io/backend/blogproject/domain/dto/PostCreateRequest.java
+++ b/src/main/java/io/backend/blogproject/domain/dto/PostCreateRequest.java
@@ -1,0 +1,15 @@
+package io.backend.blogproject.domain.dto;
+
+import io.backend.blogproject.constant.Visibility;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostCreateRequest {
+
+    private String title;
+    private String content;
+    private Visibility visibility;
+    private Long categoryId;
+}

--- a/src/main/java/io/backend/blogproject/domain/dto/PostDetailResponse.java
+++ b/src/main/java/io/backend/blogproject/domain/dto/PostDetailResponse.java
@@ -1,0 +1,45 @@
+package io.backend.blogproject.domain.dto;
+
+import io.backend.blogproject.constant.Visibility;
+import io.backend.blogproject.domain.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostDetailResponse {
+
+    private Long postId;
+    private String title;
+    private String content;
+    private Long viewedCnt;
+    private Visibility visibility;
+    private Long categoryId;
+    private String categoryTitle;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostDetailResponse from(Post post) {
+        Long categoryId = null;
+        String categoryTitle = null;
+
+        if (post.getCategory() != null) {
+            categoryId = post.getCategory().getId();
+            categoryTitle = post.getCategory().getTitle();
+        }
+
+        return new PostDetailResponse(
+                post.getPostId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getViewedCnt(),
+                post.getVisibility(),
+                categoryId,
+                categoryTitle,
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/io/backend/blogproject/domain/dto/PostListResponse.java
+++ b/src/main/java/io/backend/blogproject/domain/dto/PostListResponse.java
@@ -1,0 +1,29 @@
+package io.backend.blogproject.domain.dto;
+
+import io.backend.blogproject.constant.Visibility;
+import io.backend.blogproject.domain.entity.Post;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostListResponse {
+
+    private Long postId;
+    private String title;
+    private Long viewedCnt;
+    private Visibility visibility;
+    private LocalDateTime createdAt;
+
+    public static PostListResponse from(Post post) {
+        return new PostListResponse(
+                post.getPostId(),
+                post.getTitle(),
+                post.getViewedCnt(),
+                post.getVisibility(),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/io/backend/blogproject/domain/dto/PostUpdateRequest.java
+++ b/src/main/java/io/backend/blogproject/domain/dto/PostUpdateRequest.java
@@ -1,0 +1,15 @@
+package io.backend.blogproject.domain.dto;
+
+import io.backend.blogproject.constant.Visibility;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostUpdateRequest {
+
+    private String title;
+    private String content;
+    private Visibility visibility;
+    private Long categoryId;
+}

--- a/src/main/java/io/backend/blogproject/domain/entity/Post.java
+++ b/src/main/java/io/backend/blogproject/domain/entity/Post.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "Post")
+@Table(name = "post")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
@@ -44,19 +44,19 @@ public class Post {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private Status status;
-//
-//    @ManyToOne
-//    @JoinColumn(name = "category_id", nullable =true)
-//    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable =true)
+    private Category category;
 
     @Builder
-    public Post(String title, String content, Visibility visibility /*, Category category*/ ) {
+    public Post(String title, String content, Visibility visibility, Category category ) {
         this.title = title;
         this.content = content;
         this.visibility = visibility;
-        //this.category = category;
+        this.category = category;
         this.viewedCnt = 0L;
-        this.status = status.ACTIVATED;
+        this.status = Status.ACTIVATED;
     }
 
     @PrePersist
@@ -84,11 +84,11 @@ public class Post {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public void update(String title, String content, Visibility visibility /*, Category category*/){
+    public void update(String title, String content, Visibility visibility, Category category){
         this.title = title;
         this.content = content;
         this.visibility = visibility;
-        //this.category = category;
+        this.category = category;
     }
 
     public void increaseViewCount(){
@@ -106,4 +106,9 @@ public class Post {
     public boolean isActivated() {
         return this.status == Status.ACTIVATED;
     }
+
+    public boolean isPublic(){
+        return this.visibility == Visibility.PUBLIC;
+    }
+
 }

--- a/src/main/java/io/backend/blogproject/repository/PostRepository.java
+++ b/src/main/java/io/backend/blogproject/repository/PostRepository.java
@@ -16,5 +16,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findByPostIdAndStatus(Long postId, Status status);
 
+    Optional<Post> findByPostIdAndStatusAndVisibility(Long postId, Status status, Visibility visibility);
+
+
     List<Post> findAllByStatusAndVisibility(Status status, Visibility visibility);
+
+
 }

--- a/src/main/java/io/backend/blogproject/repository/PostRepository.java
+++ b/src/main/java/io/backend/blogproject/repository/PostRepository.java
@@ -97,6 +97,33 @@ public class PostRepository {
         }
     }
 
+    public Optional<Post> findByPostIdAndStatusAndVisibility(
+            Long postId,
+            Status status,
+            Visibility visibility
+    ) {
+        try (EntityManager em = emf.createEntityManager()) {
+            String jpql = """
+                SELECT p
+                FROM Post p
+                LEFT JOIN FETCH p.category
+                WHERE p.postId = :postId
+                AND p.status = :status
+                AND p.visibility = :visibility
+                """;
+
+            List<Post> result = em.createQuery(jpql, Post.class)
+                    .setParameter("postId", postId)
+                    .setParameter("status", status)
+                    .setParameter("visibility", visibility)
+                    .getResultList();
+
+            return result.stream().findFirst();
+        } catch (Exception e) {
+            throw new RuntimeException("게시글 조회에 실패했습니다.", e);
+        }
+    }
+
     public void update(Post post) {
         EntityManager em = emf.createEntityManager();
         EntityTransaction tx = em.getTransaction();

--- a/src/main/java/io/backend/blogproject/repository/PostRepository.java
+++ b/src/main/java/io/backend/blogproject/repository/PostRepository.java
@@ -1,0 +1,20 @@
+package io.backend.blogproject.repository;
+
+import io.backend.blogproject.constant.Status;
+import io.backend.blogproject.constant.Visibility;
+import io.backend.blogproject.domain.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findAllByStatus(Status status);
+
+    Optional<Post> findByPostIdAndStatus(Long postId, Status status);
+
+    List<Post> findAllByStatusAndVisibility(Status status, Visibility visibility);
+}

--- a/src/main/java/io/backend/blogproject/repository/PostRepository.java
+++ b/src/main/java/io/backend/blogproject/repository/PostRepository.java
@@ -3,23 +3,118 @@ package io.backend.blogproject.repository;
 import io.backend.blogproject.constant.Status;
 import io.backend.blogproject.constant.Visibility;
 import io.backend.blogproject.domain.entity.Post;
-import org.springframework.data.jpa.repository.JpaRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+@RequiredArgsConstructor
+public class PostRepository {
 
-    List<Post> findAllByStatus(Status status);
+    private final EntityManagerFactory emf;
 
-    Optional<Post> findByPostIdAndStatus(Long postId, Status status);
+    public Post save(Post post){
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction tx = em.getTransaction();
 
-    Optional<Post> findByPostIdAndStatusAndVisibility(Long postId, Status status, Visibility visibility);
+        try{
+            tx.begin();
 
+            em.persist(post);
 
-    List<Post> findAllByStatusAndVisibility(Status status, Visibility visibility);
+            tx.commit();
 
+            return post;
+        } catch (Exception e){
+            if (tx.isActive()) {
+                tx.rollback();
+            }
 
+            throw new RuntimeException("게시글 저장에 실패했습니다.", e);
+        } finally {
+            em.close();
+        }
+
+    }
+
+    public List<Post> findAllByStatus(Status status) {
+        try (EntityManager em = emf.createEntityManager()) {
+            String jpql = """
+                    SELECT p
+                    FROM Post p
+                    WHERE p.status = :status
+                    """;
+
+            return em.createQuery(jpql, Post.class)
+                    .setParameter("status", status)
+                    .getResultList();
+        } catch (Exception e) {
+            throw new RuntimeException("게시글 목록 조회에 실패했습니다.", e);
+        }
+    }
+
+    public List<Post> findAllByStatusAndVisibility(Status status, Visibility visibility) {
+        try (EntityManager em = emf.createEntityManager()) {
+            String jpql = """
+                    SELECT p
+                    FROM Post p
+                    WHERE p.status = :status
+                    AND p.visibility = :visibility
+                    """;
+
+            return em.createQuery(jpql, Post.class)
+                    .setParameter("status", status)
+                    .setParameter("visibility", visibility)
+                    .getResultList();
+        } catch (Exception e) {
+            throw new RuntimeException("공개 게시글 목록 조회에 실패했습니다.", e);
+        }
+    }
+
+    public Optional<Post> findByPostIdAndStatus(Long postId, Status status) {
+        try (EntityManager em = emf.createEntityManager()) {
+            String jpql = """
+                    SELECT p
+                    FROM Post p
+                    LEFT JOIN FETCH p.category
+                    WHERE p.postId = :postId
+                    AND p.status = :status
+                    """;
+
+            List<Post> result = em.createQuery(jpql, Post.class)
+                    .setParameter("postId", postId)
+                    .setParameter("status", status)
+                    .getResultList();
+
+            return result.stream().findFirst();
+        } catch (Exception e) {
+            throw new RuntimeException("게시글 조회에 실패했습니다.", e);
+        }
+    }
+
+    public void update(Post post) {
+        EntityManager em = emf.createEntityManager();
+        EntityTransaction tx = em.getTransaction();
+
+        try {
+            tx.begin();
+
+            em.merge(post);
+
+            tx.commit();
+        } catch (Exception e) {
+            if (tx.isActive()) {
+                tx.rollback();
+            }
+
+            throw new RuntimeException("게시글 수정에 실패했습니다.", e);
+        } finally {
+            em.close();
+        }
+    }
 }

--- a/src/main/java/io/backend/blogproject/service/PostService.java
+++ b/src/main/java/io/backend/blogproject/service/PostService.java
@@ -12,19 +12,16 @@ import io.backend.blogproject.repository.CategoryRepository;
 import io.backend.blogproject.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class PostService {
 
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
 
-    @Transactional
     public Long createPost(PostCreateRequest request){
         Category category = findCategoryOrNull(request.getCategoryId());
 
@@ -52,16 +49,15 @@ public class PostService {
                 .toList();
     }
 
-    @Transactional
     public PostDetailResponse getPost(Long postId){
         Post post = postRepository.findByPostIdAndStatusAndVisibility(postId, Status.ACTIVATED, Visibility.PUBLIC)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
         post.increaseViewCount();
+        postRepository.update(post);
 
         return PostDetailResponse.from(post);
     }
 
-    @Transactional
     public void updatePost(Long postId, PostUpdateRequest request){
         Post post = postRepository.findByPostIdAndStatus(postId, Status.ACTIVATED)
                 .orElseThrow(()->new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
@@ -76,14 +72,15 @@ public class PostService {
                 request.getVisibility(),
                 category
         );
+        postRepository.update(post);
     }
 
-    @Transactional
     public void deletePost(Long postId){
         Post post = postRepository.findByPostIdAndStatus(postId, Status.ACTIVATED)
                 .orElseThrow(()-> new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
 
         post.remove();
+        postRepository.update(post);
     }
 
     private Category findCategoryOrNull(Long categoryId) {
@@ -93,5 +90,7 @@ public class PostService {
 
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다. id=" + categoryId));
+
+        //return null;
     }
 }

--- a/src/main/java/io/backend/blogproject/service/PostService.java
+++ b/src/main/java/io/backend/blogproject/service/PostService.java
@@ -1,10 +1,20 @@
 package io.backend.blogproject.service;
 
+import io.backend.blogproject.constant.Status;
+import io.backend.blogproject.constant.Visibility;
+import io.backend.blogproject.domain.dto.PostCreateRequest;
+import io.backend.blogproject.domain.dto.PostDetailResponse;
+import io.backend.blogproject.domain.dto.PostListResponse;
+import io.backend.blogproject.domain.dto.PostUpdateRequest;
+import io.backend.blogproject.domain.entity.Category;
+import io.backend.blogproject.domain.entity.Post;
 import io.backend.blogproject.repository.CategoryRepository;
 import io.backend.blogproject.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -13,4 +23,61 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public Long createPost(PostCreateRequest request){
+        Post post = Post.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .visibility(request.getVisibility())
+                .category(null)
+                .build();
+
+        Post savedPost = postRepository.save(post);
+
+        return savedPost.getPostId();
+    }
+
+    public List<PostListResponse> getPosts(){
+        List<Post> posts = postRepository.findAllByStatusAndVisibility(
+                Status.ACTIVATED,
+                Visibility.PUBLIC
+        );
+
+
+        return posts.stream()
+                .map(PostListResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public PostDetailResponse getPost(Long postId){
+        Post post = postRepository.findByPostIdAndStatus(postId, Status.ACTIVATED)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
+        post.increaseViewCount();
+
+        return PostDetailResponse.from(post);
+    }
+
+    @Transactional
+    public void updatePost(Long postId, PostUpdateRequest request){
+        Post post = postRepository.findByPostIdAndStatus(postId, Status.ACTIVATED)
+                .orElseThrow(()->new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
+
+
+        Category category = null;
+
+        if(request.getCategoryId() != null){
+            category = categoryRepository.findById(request.getCategoryId())
+                    .orElseThrow(()->new IllegalArgumentException("카테고리를 찾을 수 없습니다. id=" + request.getCategoryId()));
+        }
+
+
+        post.update(
+                request.getTitle(),
+                request.getContent(),
+                request.getVisibility(),
+                category
+        );
+    }
 }

--- a/src/main/java/io/backend/blogproject/service/PostService.java
+++ b/src/main/java/io/backend/blogproject/service/PostService.java
@@ -26,11 +26,13 @@ public class PostService {
 
     @Transactional
     public Long createPost(PostCreateRequest request){
+        Category category = findCategoryOrNull(request.getCategoryId());
+
         Post post = Post.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .visibility(request.getVisibility())
-                .category(null)
+                .category(category)
                 .build();
 
         Post savedPost = postRepository.save(post);
@@ -38,7 +40,7 @@ public class PostService {
         return savedPost.getPostId();
     }
 
-    public List<PostListResponse> getPosts(){
+    public List<PostListResponse> getPublicPosts(){
         List<Post> posts = postRepository.findAllByStatusAndVisibility(
                 Status.ACTIVATED,
                 Visibility.PUBLIC
@@ -52,7 +54,7 @@ public class PostService {
 
     @Transactional
     public PostDetailResponse getPost(Long postId){
-        Post post = postRepository.findByPostIdAndStatus(postId, Status.ACTIVATED)
+        Post post = postRepository.findByPostIdAndStatusAndVisibility(postId, Status.ACTIVATED, Visibility.PUBLIC)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
         post.increaseViewCount();
 
@@ -65,12 +67,7 @@ public class PostService {
                 .orElseThrow(()->new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
 
 
-        Category category = null;
-
-        if(request.getCategoryId() != null){
-            category = categoryRepository.findById(request.getCategoryId())
-                    .orElseThrow(()->new IllegalArgumentException("카테고리를 찾을 수 없습니다. id=" + request.getCategoryId()));
-        }
+        Category category = findCategoryOrNull(request.getCategoryId());
 
 
         post.update(
@@ -79,5 +76,22 @@ public class PostService {
                 request.getVisibility(),
                 category
         );
+    }
+
+    @Transactional
+    public void deletePost(Long postId){
+        Post post = postRepository.findByPostIdAndStatus(postId, Status.ACTIVATED)
+                .orElseThrow(()-> new IllegalArgumentException("게시글을 찾을 수 없습니다. id="+postId));
+
+        post.remove();
+    }
+
+    private Category findCategoryOrNull(Long categoryId) {
+        if (categoryId == null) {
+            return null;
+        }
+
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다. id=" + categoryId));
     }
 }

--- a/src/main/java/io/backend/blogproject/service/PostService.java
+++ b/src/main/java/io/backend/blogproject/service/PostService.java
@@ -1,0 +1,16 @@
+package io.backend.blogproject.service;
+
+import io.backend.blogproject.repository.CategoryRepository;
+import io.backend.blogproject.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final CategoryRepository categoryRepository;
+}


### PR DESCRIPTION

#17 
>  Post Repository, DTO 및 Service 구현

## 작업 상세 내용
Post 도메인을 기반으로 게시글 생성, 조회, 수정, 삭제 기능을 처리하기 위한 Repository, DTO, Service 계층을 구현했습니다.

HTML 화면은 아직 임시 상태이므로 Controller/View 구현보다는 게시글 기능의 내부 흐름을 먼저 구성했습니다.

## 작업 상세 내용

- [x] Post Repository 구현
  - `EntityManagerFactory` 기반 Repository 방식 적용
  - 게시글 저장 기능 구현
  - 게시글 목록 조회 기능 구현
  - 게시글 단건 조회 기능 구현
  - 게시글 수정 반영을 위한 `merge` 처리 구현

- [x] Post 요청 DTO 생성
  - `PostCreateRequest`
  - `PostUpdateRequest`

- [x] Post 응답 DTO 생성
  - `PostListResponse`
  - `PostDetailResponse`
  - Entity를 Response DTO로 변환하는 `from()` 메서드 추가

- [x] Post Service 구현
  - 게시글 생성 기능 구현
  - 공개 게시글 목록 조회 기능 구현
  - 게시글 상세 조회 기능 구현
  - 상세 조회 시 조회수 증가 처리
  - 게시글 수정 기능 구현
  - 게시글 삭제 기능 구현

- [x] Soft Delete 방식 적용
  - 실제 DB 삭제가 아닌 `Status.REMOVED` 상태 변경 방식으로 삭제 처리
  - 조회 시 `Status.ACTIVATED` 게시글만 조회하도록 처리

- [x] Visibility 조건 적용
  - 목록 조회 시 `Visibility.PUBLIC` 게시글만 조회하도록 처리

- [x] Category 연동 처리
  - `category_id`가 nullable인 요구사항을 반영
  - `categoryId`가 없는 경우 `null` 허용
  - `categoryId`가 있는 경우 Category 조회 후 Post에 연결

## 참고할만한 자료(선택)
